### PR TITLE
Set PackageWWWHome and ArchiveURL

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -20,8 +20,8 @@ Date := Concatenation( ~.Date{[ 9, 10 ]}, "/", ~.Date{[ 6, 7 ]}, "/", ~.Date{[ 1
 ##  <!ENTITY VERSION "0.1-dev">
 ##  <!ENTITY RELEASEDATE "24 December 2013">
 ##  <#/GAPDoc>
-PackageWWWHome :="",
-#ArchiveURL := Concatenation( ~.PackageWWWHome, "example-", ~.Version ),
+PackageWWWHome :="https://github.com/homalg-project/InfiniteLists",
+ArchiveURL := Concatenation( ~.PackageWWWHome, "InfiniteLists-", ~.Version ),
 ArchiveFormats := ".tar.gz",
 Persons := [
   rec( 


### PR DESCRIPTION
Loading this package into gap currently leads to the following output:

#E  component `ArchiveURL' must be bound to a string started with http://, https:// or ftp://
#E  component `README_URL' must be bound to a string started with http://, https:// or ftp://
#E  component `PackageInfoURL' must be bound to a string started with http://, https:// or ftp://
#E  component `PackageWWWHome' must be bound to a string started with http://, https:// or ftp://
#E Validation of package infinitelists from /home/i/HDD/Computer/Mathematics_software/gap-4.10.0/local/pkg/InfiniteLists failed

This can be changed by setting PackageWWWHome and ArchiveURL, as proposed in this PR.